### PR TITLE
Add locking and time control

### DIFF
--- a/src/familylink/client.py
+++ b/src/familylink/client.py
@@ -107,6 +107,54 @@ class FamilyLink:
         self._cache_app_names(app_usage)
         return app_usage
 
+    def get_time_limits(self):
+        """Get members of the family."""
+
+        self._ensure_account_id()
+        response = self._session.get(
+            f"{self.BASE_URL}/people/{self.account_id}/appliedTimeLimits",
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+        print(response.text)
+        return response.json()
+
+    def set_time_limits(self, device_id, period_id, time_in_minutes):
+        """Set time limit for member of the family."""
+
+        self._ensure_account_id()
+        payload = json.dumps([None,self.account_id,[[None,None,8,device_id,None,None,None,None,None,None,None,[2,time_in_minutes,period_id]]],[1]])
+        response = self._session.post(
+            f"{self.BASE_URL}/people/{self.account_id}/timeLimitOverrides:batchCreate",
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def lock_device(self, device_id):
+        """Lock a device"""
+        payload = json.dumps([None,self.account_id,[[None,None,1,device_id]],[1]])
+
+        self._ensure_account_id()
+        response = self._session.post(
+            f"{self.BASE_URL}/people/{self.account_id}/timeLimitOverrides:batchCreate",
+            content=payload,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def unlock_device(self, device_id):
+        """unlock a device"""
+        payload = json.dumps([None,self.account_id,[[None,None,4,device_id]],[1]])
+
+        self._ensure_account_id()
+        response = self._session.post(
+            f"{self.BASE_URL}/people/{self.account_id}/timeLimitOverrides:batchCreate",
+            content=payload,
+        )
+        response.raise_for_status()
+        return response.json()
+
     def update_app_restrictions(
         self,
         app_name: str,

--- a/src/familylink/client.py
+++ b/src/familylink/client.py
@@ -130,7 +130,7 @@ class FamilyLink:
         response.raise_for_status()
         return response.json()
 
-    def set_time_limits(self,
+    def set_time_limits_device(self,
                         account_id: str | None = None,
                         device_id: str = "",
                         period_id: str = "",
@@ -146,6 +146,31 @@ class FamilyLink:
         )
         response.raise_for_status()
         return response.json()
+
+    def disable_time_limits_device(self,
+                        account_id: str | None = None,
+                        device_id: str = "",
+                        period_id: str = "",
+                        time_in_minutes: int = 0):
+        """Set time limit for member of the family."""
+
+        if not account_id:
+            account_id = self._ensure_account_id()
+        payload = json.dumps([None,account_id,[[None,None,8,device_id,None,None,None,None,None,None,None,[1,time_in_minutes,period_id]]],[1]])
+        response = self._session.post(
+            f"{self.BASE_URL}/people/{account_id}/timeLimitOverrides:batchCreate",
+            content=payload
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def enable_time_limits_device(self,
+                        account_id: str | None = None,
+                        device_id: str = "",
+                        period_id: str = "",
+                        time_in_minutes: int = 0):
+        """Set time limit for member of the family."""
+        self.set_time_limits_device(account_id, device_id, period_id, time_in_minutes)
 
     def lock_device(self,
                     account_id: str | None = None,
@@ -177,6 +202,50 @@ class FamilyLink:
         )
         response.raise_for_status()
         return response.json()
+
+    def turn_off_downtime_device(self,
+                                 account_id: str | None = None,
+                                 device_id: str  = "",
+                                 start_hour: int = 0,
+                                 start_minute: int = 0,
+                                 end_hour: int = 0,
+                                 end_minute: int = 0,
+                                 period_id: str = ""
+                                 ):
+        """Turn off downtime for a device"""
+        if not account_id:
+            account_id = self._ensure_account_id()
+        payload = json.dumps([None,account_id,[[None,None,9,None,None,None,None,None,None,None,None,None,[1,[start_hour,end_minute],[end_hour,end_minute],period_id]]],[1]])
+
+        response = self._session.post(
+            f"{self.BASE_URL}/people/{account_id}/timeLimitOverrides:batchCreate",
+            content=payload,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def turn_on_downtime_device(self,
+                                 account_id: str | None = None,
+                                 device_id: str  = "",
+                                 start_hour: int = 0,
+                                 start_minute: int = 0,
+                                 end_hour: int = 0,
+                                 end_minute: int = 0,
+                                 period_id: str = ""
+                                 ):
+        """Turn on downtime for a device"""
+        if not account_id:
+            account_id = self._ensure_account_id()
+
+        payload = json.dumps([None,account_id,[[None,None,9,None,None,None,None,None,None,None,None,None,[2,[start_hour,end_minute],[end_hour,end_minute],period_id]]],[1]])
+
+        response = self._session.post(
+            f"{self.BASE_URL}/people/{account_id}/timeLimitOverrides:batchCreate",
+            content=payload,
+        )
+        response.raise_for_status()
+        return response.json()
+
 
     def update_app_restrictions(
         self,

--- a/src/familylink/client.py
+++ b/src/familylink/client.py
@@ -142,7 +142,7 @@ class FamilyLink:
         payload = json.dumps([None,account_id,[[None,None,8,device_id,None,None,None,None,None,None,None,[2,time_in_minutes,period_id]]],[1]])
         response = self._session.post(
             f"{self.BASE_URL}/people/{account_id}/timeLimitOverrides:batchCreate",
-            headers={"Content-Type": "application/json"},
+            content=payload
         )
         response.raise_for_status()
         return response.json()

--- a/src/familylink/client.py
+++ b/src/familylink/client.py
@@ -116,48 +116,63 @@ class FamilyLink:
         self._cache_app_names(app_usage)
         return app_usage
 
-    def get_time_limits(self):
+    def get_time_limits(self,
+                        account_id: str | None = None,
+                        ):
         """Get members of the family."""
 
-        self._ensure_account_id()
+        if not account_id:
+            account_id = self._ensure_account_id()
         response = self._session.get(
-            f"{self.BASE_URL}/people/{self.account_id}/appliedTimeLimits",
+            f"{self.BASE_URL}/people/{account_id}/appliedTimeLimits",
             headers={"Content-Type": "application/json"},
         )
         response.raise_for_status()
         return response.json()
 
-    def set_time_limits(self, device_id, period_id, time_in_minutes):
+    def set_time_limits(self,
+                        account_id: str | None = None,
+                        device_id: str = "",
+                        period_id: str = "",
+                        time_in_minutes: int = 0):
         """Set time limit for member of the family."""
 
-        self._ensure_account_id()
-        payload = json.dumps([None,self.account_id,[[None,None,8,device_id,None,None,None,None,None,None,None,[2,time_in_minutes,period_id]]],[1]])
+        if not account_id:
+            account_id = self._ensure_account_id()
+        payload = json.dumps([None,account_id,[[None,None,8,device_id,None,None,None,None,None,None,None,[2,time_in_minutes,period_id]]],[1]])
         response = self._session.post(
-            f"{self.BASE_URL}/people/{self.account_id}/timeLimitOverrides:batchCreate",
+            f"{self.BASE_URL}/people/{account_id}/timeLimitOverrides:batchCreate",
             headers={"Content-Type": "application/json"},
         )
         response.raise_for_status()
         return response.json()
 
-    def lock_device(self, device_id):
+    def lock_device(self,
+                    account_id: str | None = None,
+                    device_id: str  = ""):
         """Lock a device"""
-        payload = json.dumps([None,self.account_id,[[None,None,1,device_id]],[1]])
+        if not account_id:
+            account_id = self._ensure_account_id()
+        payload = json.dumps([None,account_id,[[None,None,1,device_id]],[1]])
 
-        self._ensure_account_id()
         response = self._session.post(
-            f"{self.BASE_URL}/people/{self.account_id}/timeLimitOverrides:batchCreate",
+            f"{self.BASE_URL}/people/{account_id}/timeLimitOverrides:batchCreate",
             content=payload,
         )
         response.raise_for_status()
         return response.json()
 
-    def unlock_device(self, device_id):
+    def unlock_device(self,
+                      account_id: str | None = None,
+                      device_id: str = ""):
         """unlock a device"""
-        payload = json.dumps([None,self.account_id,[[None,None,4,device_id]],[1]])
+        if not account_id:
+            account_id = self._ensure_account_id()
+        payload = json.dumps([None,account_id,[[None,None,4,device_id]],[1]])
 
         self._ensure_account_id()
         response = self._session.post(
-            f"{self.BASE_URL}/people/{self.account_id}/timeLimitOverrides:batchCreate",
+            f"{self.BASE_URL}/people/{account_id}/timeLimitOverrides:batchCreate",
             content=payload,
         )
         response.raise_for_status()

--- a/src/familylink/client.py
+++ b/src/familylink/client.py
@@ -203,7 +203,7 @@ class FamilyLink:
         response.raise_for_status()
         return response.json()
 
-    def turn_off_downtime_device(self,
+    def disable_downtime_device(self,
                                  account_id: str | None = None,
                                  device_id: str  = "",
                                  start_hour: int = 0,
@@ -224,7 +224,7 @@ class FamilyLink:
         response.raise_for_status()
         return response.json()
 
-    def turn_on_downtime_device(self,
+    def enable_downtime_device(self,
                                  account_id: str | None = None,
                                  device_id: str  = "",
                                  start_hour: int = 0,


### PR DESCRIPTION
I realize this isnt exactly in format you needed but wanted to share regardless.  I tested that all these endpoints work.
added support to modify todays settings for

- set time limit for a device
- disable all time limits for a device
- enable previous time limits for a device
- lock device
- unlock device
- enable downtime for a device
- disable downtime for a device

I also added support to just bringing over a cookie file rather than the whole browser sync.  My goal is to run this inside home assistant at some point. so will be easier to copy over one cookie file rather than have it sync my whole browser.  thanks for starting library